### PR TITLE
Fix FastMenu

### DIFF
--- a/FastMenu/README.md
+++ b/FastMenu/README.md
@@ -4,6 +4,20 @@ Several patches to speed up the loading of the main settings menu:
 - Remove another animation for fading in the menu contents (why do they have two).
 - Eagerly load the menu contents; without this the first time has an extra delay.
 
+## Requirements
+
+- in src\webpack\common\components.ts at line 29 add the code below.
+
+```
+FocusLock: t.FocusLock,
+```
+
+- in src\webpack\common\types\components.d.ts at line 38 add the code below.
+
+```
+export type FocusLock = ComponentType<FocusLock>;
+```
+
 ### A note on themes
 
 If you use a theme like *Modal settings window*, this plugin interferes with

--- a/FastMenu/index.tsx
+++ b/FastMenu/index.tsx
@@ -1,3 +1,9 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { definePluginSettings } from "@api/Settings";
 import { classNameFactory } from "@api/Styles";
 import definePlugin, { OptionType } from "@utils/types";
@@ -18,9 +24,9 @@ const settings = definePluginSettings({
     },
 });
 
-const lazyLayers = [];
+const lazyLayers: any[] = [];
 function eagerLoad() {
-    lazyLayers.forEach(wreq.el);
+    lazyLayers.forEach((wreq as any).el);
 }
 
 export default definePlugin({
@@ -55,7 +61,7 @@ export default definePlugin({
 
     Layer({ mode, baseLayer = false, ...props }) {
         const hidden = mode === "HIDDEN";
-        const containerRef = useRef();
+        const containerRef = useRef<HTMLDivElement | null>(null);
         const node = <div
             ref={containerRef}
             aria-hidden={hidden}


### PR DESCRIPTION
Fast Menu had 5 errors total
1st is the fact wreq.el doesn't exist on wreq which is where (wreq as any).el comes in.
2nd useRef() caused an error and needed to be defined as a divelement (div makes the most sense imo).
3rd lazyLayer needs to be any so moduleId doesnt error.
4th FocusLock doesnt exist on Forms so I added it to the readme as a req.
5th was the useRef's module being mad that it wasn't used correctly.