### PR TITLE
fix(classify): handle null in remap/1

### DIFF
--- a/Classify/index.ts
+++ b/Classify/index.ts
@@ -71,7 +71,8 @@ export default definePlugin({
         }
     },
 
-    remap(className: string) {
+    remap(className: string | null) {
+        if (!className) return className;
         return className.split(" ").map(c => this.classes[c] ?? c).join("\n");
     },
 


### PR DESCRIPTION
sometimes this crashes discord; null can be passed as a class to remove the attribute, apparently